### PR TITLE
User-API improvements

### DIFF
--- a/app/classes/Controller/UserController.php
+++ b/app/classes/Controller/UserController.php
@@ -43,6 +43,7 @@ class UserController
 
     /**
      * @param User $user
+     * @return User
      */
     public function createUser(User $user)
     {
@@ -50,6 +51,8 @@ class UserController
         $user->setEditedDate(new \DateTime());
         $this->entityManager->persist($user);
         $this->entityManager->flush();
+
+        return $user;
     }
 
     /**

--- a/app/classes/Converter/AbstractConverter.php
+++ b/app/classes/Converter/AbstractConverter.php
@@ -2,6 +2,7 @@
 namespace KCMS\Converter;
 
 use Doctrine\ORM\EntityManager;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class AbstractConverter
@@ -30,8 +31,9 @@ abstract class AbstractConverter
     abstract public function convertFromId($id);
 
     /**
-     * @param $json
+     * @param         $null
+     * @param Request $request
      * @return object
      */
-    abstract public function convertFromJson($json);
+    abstract public function convertFromRequestBody($null, Request $request);
 }

--- a/app/classes/Converter/ConverterAdapter.php
+++ b/app/classes/Converter/ConverterAdapter.php
@@ -1,6 +1,8 @@
 <?php
 namespace KCMS\Converter;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /**
  * Class ConverterAdapter
  * @package KCMS\Converter
@@ -17,10 +19,11 @@ class ConverterAdapter extends AbstractConverter
     }
 
     /**
-     * @param $json
+     * @param         $null
+     * @param Request $request
      * @return object
      */
-    public function convertFromJson($json)
+    public function convertFromRequestBody($null, Request $request)
     {
         return null;
     }

--- a/app/classes/Converter/UserConverter.php
+++ b/app/classes/Converter/UserConverter.php
@@ -2,6 +2,7 @@
 namespace KCMS\Converter;
 
 use KCMS\Models\User;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
@@ -26,13 +27,13 @@ class UserConverter extends AbstractConverter
     }
 
     /**
-     * @param $json
+     * @param         $null
+     * @param Request $request
      * @return User
-     * @throws \InvalidArgumentException
      */
-    public function convertFromJson($json)
+    public function convertFromRequestBody($null, Request $request)
     {
-        $decoded = json_decode($json, true);
+        $decoded = json_decode($request->getContent(), true);
 
         $user = User::createUser(
             $decoded['username'] ?: null,

--- a/app/classes/Models/User.php
+++ b/app/classes/Models/User.php
@@ -310,6 +310,7 @@ class User implements \JsonSerializable, ValidationInterface
     public function jsonSerialize()
     {
         return [
+            'id'          => $this->id,
             "username"    => $this->username,
             "firstName"   => $this->firstName,
             "lastName"    => $this->lastName,

--- a/app/classes/Validation/ValidationException.php
+++ b/app/classes/Validation/ValidationException.php
@@ -17,7 +17,7 @@ class ValidationException extends \Exception
      * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      * @since 5.1.0
      */
-    public function __construct($message = "", $code = 401, Exception $previous = null)
+    public function __construct($message = "", $code = 400, Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/app/public/index.php
+++ b/app/public/index.php
@@ -44,7 +44,7 @@ $app['user.controller'] = $app->share(function () use ($app) {
 $user = $app['controllers_factory'];
 $user->get('/', 'user.controller:getAllUsers');
 $user->get('/{user}', 'user.controller:getUser')->convert('user', 'user.converter:convertFromId');
-$user->put('/{user}', 'user.controller:createUser')->convert('user', 'user.converter:convertFromJson');
+$user->post('/', 'user.controller:createUser')->convert('user', 'user.converter:convertFromRequestBody');
 $user->delete('/{user}', 'user.controller:deleteUser')->convert('user', 'user.converter:convertFromId');
 
 // Mount user controller
@@ -62,7 +62,8 @@ $app->view(function ($controllerResult, \Symfony\Component\HttpFoundation\Reques
             }
             break;
         case 'PUT':
-            return new \Symfony\Component\HttpFoundation\Response('', $status = 201);
+        case 'POST':
+            return new \Symfony\Component\HttpFoundation\JsonResponse($controllerResult, $status = 201);
             break;
         case 'DELETE':
             return new \Symfony\Component\HttpFoundation\Response('', $status = 204);

--- a/test/Tests/UsersTest.php
+++ b/test/Tests/UsersTest.php
@@ -37,15 +37,15 @@ class UsersTest extends PHPUnit_Framework_TestCase
 
     public function testUserAdd()
     {
-        $response = $this->guzzleClient->put(
-            'users/{' .
-            '"username":"' . $this->testUser->getUsername() .
-            '","firstName":"' . $this->testUser->getFirstName() .
-            '","lastName":"' . $this->testUser->getLastName() .
-            '","email":"' . $this->testUser->getEmail()
-            . '","password":"' . $this->testUser->getPassword() .
-            '"}'
-        );
+        $response = $this->guzzleClient->post('users/', [
+            'body' => json_encode([
+                'username'  => $this->testUser->getUsername(),
+                'firstName' => $this->testUser->getFirstName(),
+                'lastName'  => $this->testUser->getLastName(),
+                'email'     => $this->testUser->getEmail(),
+                'password'  => $this->testUser->getPassword()
+            ])
+        ]);
 
         $this->assertEquals(201, $response->getStatusCode());
     }

--- a/test/Tests/UsersTest.php
+++ b/test/Tests/UsersTest.php
@@ -35,6 +35,9 @@ class UsersTest extends PHPUnit_Framework_TestCase
         $this->testUser = $testUser;
     }
 
+    /**
+     * @return int
+     */
     public function testUserAdd()
     {
         $response = $this->guzzleClient->post('users/', [
@@ -48,14 +51,18 @@ class UsersTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertEquals(201, $response->getStatusCode());
+        $user = json_decode($response->getBody(), true);
+
+        return $user['id'];
     }
 
     /**
      * @depends testUserAdd
+     * @param $userId
      */
-    public function testUserGet()
+    public function testUserGet($userId)
     {
-        $response = $this->guzzleClient->get('users/1');
+        $response = $this->guzzleClient->get('users/' . $userId);
 
         $this->assertEquals(200, $response->getStatusCode());
 
@@ -64,5 +71,20 @@ class UsersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->testUser->getFirstName(), $user['firstName']);
         $this->assertEquals($this->testUser->getLastName(), $user['lastName']);
         $this->assertEquals($this->testUser->getEmail(), $user['email']);
+
+        return $userId;
+    }
+
+    /**
+     * @depends testUserGet
+     * @param $userId
+     */
+    public function testUserDelete($userId)
+    {
+        $response = $this->guzzleClient->delete('users/' . $userId);
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $response2 = $this->guzzleClient->get('users/' . $userId);
+        $this->assertEquals(404, $response2->getStatusCode());
     }
 }


### PR DESCRIPTION
- JSON-serialized new user for the user->new post route is now submitted using the request body
- Converters have been adjusted
- Tests are adjusted

One note on the test, apparently
```php
        $response = $this->guzzleClient->post('users/', [
            'body' => json_encode([
                'username'  => $this->testUser->getUsername(),
                'firstName' => $this->testUser->getFirstName(),
                'lastName'  => $this->testUser->getLastName(),
                'email'     => $this->testUser->getEmail(),
                'password'  => $this->testUser->getPassword()
            ])
        ]);
```
and
```php
        $response = $this->guzzleClient->post('users/', [
            'json' => [
                'username'  => $this->testUser->getUsername(),
                'firstName' => $this->testUser->getFirstName(),
                'lastName'  => $this->testUser->getLastName(),
                'email'     => $this->testUser->getEmail(),
                'password'  => $this->testUser->getPassword()
            ]
        ]);
```
are not equal, as the test fails on PHP 5.6 (5.4 and 5.5 are fine). I assume it has to do with the content headers, though I do not think there is a place where we check for them.
